### PR TITLE
Improve `heating_system` modelling in `domestic_heating.dim_households`

### DIFF
--- a/cnz/models/marts/domestic_heating/dim_households.sql
+++ b/cnz/models/marts/domestic_heating/dim_households.sql
@@ -73,10 +73,18 @@ epc_features as (
         case
             when heat_pump_source = 'air' then 'air_source_heat_pump'
             when heat_pump_source = 'ground' then 'ground_source_heat_pump'
-            when main_fuel = 'gas' or main_hotwater_fuel = 'gas' then 'gas_boiler'
-            when main_fuel = 'electricity' or main_hotwater_fuel = 'electricity' then 'electric_boiler'
-            -- treat all oil/lpg/solid fuel/biomass houses as 'oil boiler' houses in our modelling
-            when main_fuel is not null or main_hotwater_fuel is not null then 'oil_boiler'
+            -- Prioritise main_fuel column first
+            when main_fuel = 'gas' then 'gas_boiler'
+            when main_fuel = 'electricity' then 'electric_boiler'
+            when main_fuel is not null then 'oil_boiler'
+            -- Then main_heat_fuel second
+            when main_heat_fuel = 'gas' then 'gas_boiler'
+            when main_heat_fuel = 'electricity' then 'electric_boiler'
+            when main_heat_fuel is not null then 'oil_boiler'
+            -- and finally main_hotwater_fuel
+            when main_hotwater_fuel = 'gas' then 'gas_boiler'
+            when main_hotwater_fuel = 'electricity' then 'electric_boiler'
+            when main_hotwater_fuel is not null then 'oil_boiler'
         end as heating_system,
 
         -- Energy efficiencies

--- a/cnz/models/marts/domestic_heating/domestic_heating.yml
+++ b/cnz/models/marts/domestic_heating/domestic_heating.yml
@@ -56,6 +56,11 @@ models:
           - accepted_values:
               values: ['A', 'B', 'C', 'D', 'E', 'F', 'G']
       - name: heating_system
+        description:
+          Derived heating system for our modelling using fuel source.
+          We treat all oil/lpg/solid fuel/biomass houses as 'oil_boiler' houses in our modelling.
+          main_fuel is considered first, then main_heat_fuel, then main_hotwater_fuel.
+          Main sources of missingness from description cols is sap05 values and 'community scheme' heating where fuel source is unknown
         tests:
           - accepted_values:
               values: ['air_source_heat_pump', 'ground_source_heat_pump', 'gas_boiler', 'electric_boiler', 'oil_boiler']


### PR DESCRIPTION
Derive the heating system using the following 4 columns, in order of prioritisation:

1. Heat pumps, if applicable
2. `main_fuel`
3. `main_heat_fuel`
4.  `main_hotwater_fuel`

This increases the coverage of non-null `heating_system` values, and is more accurate.

There is still missingness and modelling choices for the following two main categories:
1. `SAP05` fuel description column values.
2. Community energy schemes where the fuel source is unknown (`main_heat_description = 'community scheme'` or `hot_water_description = 'community scheme'`)

We make no assumption on fuel source for these households in `domestic_heating.dim_households`.

This reduces the number of null `heating_system` values from ~450k households to ~302k households.