### PR TITLE
Fix `is_heat_pump_suitable_archetype` rule in `dim_households`

### DIFF
--- a/cnz/models/marts/domestic_heating/dim_households.sql
+++ b/cnz/models/marts/domestic_heating/dim_households.sql
@@ -112,7 +112,9 @@ final as (
         null as local_authority_district_name_2020,
         epc_features.*,
         null as property_value_gbp,
-        epc_features.property_type not in ("flat", "park home", "mid_terrace") as is_heat_pump_suitable_archetype,
+        epc_features.property_type not in (
+            'flat', 'park home'
+        ) and epc_features.built_form != 'mid_terrace' as is_heat_pump_suitable_archetype,
         off_gas_postcodes.postcode is not null as is_off_gas_grid
 
     from epc_features


### PR DESCRIPTION
This PR issues a minor fix, since `mid_terrace` is in `built_form` (and not `property_type`).