### PR TITLE
add uprn to dim_households and remove redundant location fields

### DIFF
--- a/cnz/models/marts/domestic_heating/dim_households.sql
+++ b/cnz/models/marts/domestic_heating/dim_households.sql
@@ -16,10 +16,11 @@ latest_building_certificates as (
         select
             *,
             row_number() over (
-                partition by building_reference_number order by inspection_date desc
+                partition by uprn order by inspection_date desc
             ) as most_recent_building_certificate_ordinal
 
         from certificates
+        where uprn is not null
 
     )
 
@@ -39,6 +40,7 @@ nsul as (
         uprn,
         local_authority_district_name
     from {{ ref('stg_nsul__addresses') }}
+
 ),
 
 epc_features as (
@@ -122,7 +124,7 @@ final as (
 
     from epc_features
     left join off_gas_postcodes on epc_features.postcode = off_gas_postcodes.postcode
-    left join nsul on nsul.uprn = epc_features.uprn
+    join nsul on nsul.uprn = epc_features.uprn
 
 )
 

--- a/cnz/models/marts/domestic_heating/domestic_heating.yml
+++ b/cnz/models/marts/domestic_heating/domestic_heating.yml
@@ -5,6 +5,9 @@ models:
   - name: dim_households
     columns:
       - name: uprn
+        tests:
+          - unique
+          - not_null
       - name: postcode
       - name: property_value_gbp
         tests:


### PR DESCRIPTION
- Adds the `uprn` field from `stg_epc__england_wales_certificates` tables to `dim_households`
- Uses it instead of `building_reference_number` to identify the most recent EPC per household. A data quality issue has become apparent with `building_reference_number`; different values can reference the same property.
- Joins NSUL data, to also add `local_authority_district_name_2020`
- Removes address fields which are not ingested by the ABM / redundant with the addition of uprn