### PR TITLE
Ignore district heating in `dim_households`

### DIFF
--- a/cnz/models/marts/domestic_heating/base/base_domestic_heating__epc_features.sql
+++ b/cnz/models/marts/domestic_heating/base/base_domestic_heating__epc_features.sql
@@ -72,6 +72,9 @@ epc_features as (
 
         -- Heating system modelling
         case
+            -- Ignore district heating
+            when has_district_heating then null
+            -- Heat pumps
             when heat_pump_source = 'air' then 'air_source_heat_pump'
             when heat_pump_source = 'ground' then 'ground_source_heat_pump'
             -- Prioritise main_fuel column first


### PR DESCRIPTION
Any properties with "community scheme" in their main_heat_description (`has_district_heating = true`) are marked with a `null` `heating_system` in `dim_households`, and are not considered in the ABM